### PR TITLE
MAIN - Alert, import other components from parent

### DIFF
--- a/src/Alerts/Alert.jsx
+++ b/src/Alerts/Alert.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Row, Col, Icon } from "../../src/index";
+import { Row, Col, Icon } from "../index";
 import { AlertStyles, ContentStyles } from "./alert.style";
 import * as AlertTypes from "./alertTypes";
 

--- a/src/Alerts/AlertSmall.jsx
+++ b/src/Alerts/AlertSmall.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Row, Col, Icon } from "../../src/index";
+import { Row, Col, Icon } from "../index";
 import { AlertStyles } from "./alert.style";
 import * as AlertTypes from "./alertTypes";
 


### PR DESCRIPTION
The alert component imports other components by going all the way back to the root, then through the src folder. This breaks when using vivy-components as a package as the src folder is missing.

I missed this as I was testing with yarn linked packages. 