### PR TITLE
MAIN - Sidebar, import components from parent 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "build:storybook": "storybook-to-ghpages",
     "build:static": "build-storybook -s public",
     "build:package": "babel --presets @babel/react ./src --out-dir ./dist",
-    "test": "jest",
+    "test": "npm run build:package && jest",
+    "test:dist": "npm run build:package && node tests/dist.test.js",
     "danger": "danger ci",
     "test:watch": "npm run test -- --watchAll"
   },
@@ -71,12 +72,31 @@
     "react-test-renderer": "16.8.1"
   },
   "jest": {
-    "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|svg|ttf|woff|woff2|eot)$": "<rootDir>/.jest/assetsTransformer.js",
-      "\\.(css)$": "<rootDir>/.jest/styleMock.js"
-    },
-    "setupFiles": [
-      "<rootDir>/.jest/registerContext.js"
+    "projects": [
+      {
+        "displayName": "Snapshots",
+        "moduleNameMapper": {
+          "\\.(jpg|jpeg|png|gif|svg|ttf|woff|woff2|eot)$": "<rootDir>/.jest/assetsTransformer.js",
+          "\\.(css)$": "<rootDir>/.jest/styleMock.js"
+        },
+        "setupFiles": [
+          "<rootDir>/.jest/registerContext.js"
+        ],
+        "testMatch": [
+          "<rootDir>/tests/storyshots*.js"
+        ]
+      },
+      {
+        "displayName": "Dist",
+        "moduleNameMapper": {
+          "\\.(jpg|jpeg|png|gif|svg|ttf|woff|woff2|eot)$": "<rootDir>/.jest/assetsTransformer.js",
+          "\\.(css)$": "<rootDir>/.jest/styleMock.js",
+          "/src/(.*)": "ERROR: Imports should not include the src folder"
+        },
+        "testMatch": [
+          "<rootDir>/tests/dist.test.js"
+        ]
+      }
     ]
   }
 }

--- a/src/Sidebar/Sidebar.jsx
+++ b/src/Sidebar/Sidebar.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Row, Col, Icon } from "../../src/index";
+import { Row, Col, Icon } from "../index";
 import {
   SidebarStyles,
   LinkStyles,

--- a/tests/dist.test.js
+++ b/tests/dist.test.js
@@ -1,0 +1,5 @@
+const Components = require("../dist/index");
+
+it("should have a working dist", () => {
+  expect(Components).toBeDefined();
+});


### PR DESCRIPTION
The current dist is broken as the Sidebar imports the index from `../../src` rather than `../`.

This mistake is easy to make as a lot of our stories import this way, and there is no easy way to tell that the dist is broken until a release is made.

So as part of this PR I added a simple test that breaks if the dist imports something from `src`, this is done by creating another jest project and remapping any imports with `src` in them so they produce an error. 