### PR TITLE
Do not use empty strings for download or rel attributes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
 
       - run: npm install
       - run: npm run build:static
@@ -25,8 +25,13 @@ jobs:
 
       - save_cache:
           paths:
-          - node_modules
+            - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
+
+      # Allow us to see failed storyshot diff files in the circle CI artifacts UI
+      - store_artifacts:
+          path: ~/repo/tests/__image_snapshots__/__diff_output__
+          destination: storyshot-diffs
 
   release:
     docker:
@@ -38,9 +43,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
 
       # Update package.json version
       - run: npm version $CIRCLE_TAG && git push origin HEAD:master

--- a/src/Buttons/AnchorButton.jsx
+++ b/src/Buttons/AnchorButton.jsx
@@ -37,7 +37,7 @@ AnchorButton.propTypes = {
   onClick: PropTypes.func,
   target: PropTypes.string,
   rel: PropTypes.string,
-  download: PropTypes.string,
+  download: PropTypes.oneOf([PropTypes.bool, PropTypes.string]),
   style: PropTypes.shape({}),
   className: PropTypes.string
 };
@@ -46,8 +46,8 @@ AnchorButton.defaultProps = {
   type: "primary",
   onClick: () => {},
   target: "_self",
-  rel: "",
-  download: "",
+  rel: null,
+  download: null,
   style: {},
   className: ""
 };


### PR DESCRIPTION
Currently the anchor buttons defaults for the `download` and `rel` prop is an empty string. 

This means that all `AnchorButtons` will have the `download` attribute set, and instead of navigating will download the page. 

This PR changes the default to null, which means the `download` attribute wont be set on the anchor. 